### PR TITLE
Rhmap 9814

### DIFF
--- a/lib/common/authenticate.js
+++ b/lib/common/authenticate.js
@@ -28,7 +28,7 @@ module.exports = function(req, res, params) {
   var DEFAULT_KEY = "default";
   var UNAUTHORISED_HTTP_CODE = 401;
 
-  var DEFAULT_CACHE_REFRESH_SECONDS = 60;
+  var DEFAULT_CACHE_REFRESH_SECONDS = 3600;
   var CACHE_REFRESH_KEY = "AUTH_CACHE_REFRESH_SECONDS";
 
   /**
@@ -360,7 +360,7 @@ module.exports = function(req, res, params) {
         "url": authEndpoint,
         headers: headers
       }, function(err, res, data) {
-        var cacheLength = now + (1000 * 60 * getCacheRefreshInterval());
+        var cacheLength = now + (1000 * getCacheRefreshInterval());
         if (err) {
           return cb(err);
         }

--- a/lib/common/authenticate.js
+++ b/lib/common/authenticate.js
@@ -28,6 +28,9 @@ module.exports = function(req, res, params) {
   var DEFAULT_KEY = "default";
   var UNAUTHORISED_HTTP_CODE = 401;
 
+  var DEFAULT_CACHE_REFRESH_SECONDS = 60;
+  var CACHE_REFRESH_KEY = "AUTH_CACHE_REFRESH_SECONDS";
+
   /**
    * private
    */
@@ -233,6 +236,22 @@ module.exports = function(req, res, params) {
     }
   }
 
+  /**
+   * The refresh interval of the authentication cache should be configurable. Since
+   * this is running inside a cloud app the best option is th use an environment
+   * variable.
+   * @returns {*}
+   */
+  function getCacheRefreshInterval() {
+    var value = parseInt(process.env[CACHE_REFRESH_KEY]);
+
+    // Should we 0 here to invalidate the cache immediately?
+    if (value && !isNaN(value) && value > 0) {
+      return value;
+    }
+
+    return DEFAULT_CACHE_REFRESH_SECONDS;
+  }
 
   return {
     /**
@@ -341,7 +360,7 @@ module.exports = function(req, res, params) {
         "url": authEndpoint,
         headers: headers
       }, function(err, res, data) {
-        var cacheLength = now + (1000 * 60 * 60);
+        var cacheLength = now + (1000 * 60 * getCacheRefreshInterval());
         if (err) {
           return cb(err);
         }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "FeedHenry MBAAS Express",
   "main": "lib/webapp.js",
   "dependencies": {
@@ -36,7 +36,7 @@
     "turbo-test-runner": "~0.3"
   },
   "scripts": {
-    "test": "grunt fh:coverage fh:analysis fh:dist"
+    "test": "grunt fh:coverage fh:dist"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-express
 sonar.projectName=fh-mbaas-express-nightly-master
-sonar.projectVersion=5.6.1
+sonar.projectVersion=5.6.2
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation

we want the auth cache interval to be configurable. Since this code is running in a Cloud App the best way to do it is via environment variable. If a variable `AUTH_CACHE_REFRESH_SECONDS` is defined then it will be used to retrieve the cache length. Otherwise we use a default value of 1 hour.

ping @wei-lee @ziccardi @TommyJ1994 @witmicko @aliok 
