### PR TITLE
RHMAP-9815 send permission level to millicore if possible

### DIFF
--- a/lib/common/authenticate.js
+++ b/lib/common/authenticate.js
@@ -233,6 +233,20 @@ module.exports = function(req, res, params) {
     }
   }
 
+  /**
+   * If `params` has the `requestedPermission` property we append it to the URL. Millicore
+   * can then differ between read and write permissions for the given action.
+   *
+   * @param url Millicore request URL
+   * @returns {string} URL string
+   */
+  function appendRequestedPermission(url) {
+    if(params.requestedPermission) {
+      return url + "&requestedAct=" + params.requestedPermission;
+    }
+
+    return url;
+  }
 
   return {
     /**
@@ -334,6 +348,9 @@ module.exports = function(req, res, params) {
       }
 
       var authEndpoint = millicoreProt + "://" + millicore + "/box/api/mbaas/admin/authenticateRequest?appApiKey=" + appApiKey + "&env=" + env + "&requestedPerm=" + requestedPerm;
+
+      // Append `requestedAct` query parameter if possible
+      authEndpoint = appendRequestedPermission(authEndpoint);
 
       var headers = {};
       headers[USER_HEADER_KEY.toUpperCase()] = userApiKey;

--- a/lib/common/authenticate.js
+++ b/lib/common/authenticate.js
@@ -28,6 +28,9 @@ module.exports = function(req, res, params) {
   var DEFAULT_KEY = "default";
   var UNAUTHORISED_HTTP_CODE = 401;
 
+  var DEFAULT_CACHE_REFRESH_SECONDS = 3600;
+  var CACHE_REFRESH_KEY = "AUTH_CACHE_REFRESH_SECONDS";
+
   /**
    * private
    */
@@ -234,6 +237,23 @@ module.exports = function(req, res, params) {
   }
 
   /**
+   * The refresh interval of the authentication cache should be configurable. Since
+   * this is running inside a cloud app the best option is th use an environment
+   * variable.
+   * @returns {*}
+   */
+  function getCacheRefreshInterval() {
+    var value = parseInt(process.env[CACHE_REFRESH_KEY]);
+
+    // Should we 0 here to invalidate the cache immediately?
+    if (value && !isNaN(value) && value > 0) {
+      return value;
+    }
+
+    return DEFAULT_CACHE_REFRESH_SECONDS;
+  }
+
+  /**
    * If `params` has the `requestedPermission` property we append it to the URL. Millicore
    * can then differ between read and write permissions for the given action.
    *
@@ -358,7 +378,7 @@ module.exports = function(req, res, params) {
         "url": authEndpoint,
         headers: headers
       }, function(err, res, data) {
-        var cacheLength = now + (1000 * 60 * 60);
+        var cacheLength = now + (1000 * getCacheRefreshInterval());
         if (err) {
           return cb(err);
         }

--- a/lib/mbaas.js
+++ b/lib/mbaas.js
@@ -30,6 +30,21 @@ function applyAuth(req, res,api,role,callback){
     }],callback);
 }
 
+/**
+ * DB actions are bound to specific permissions. For example the `list` action
+ * requires only read permissions while `update` requires write. Those permissions
+ * are configured in the `permission-map` of fh-db. If the given action has a
+ * permission set we will add that to the params, otherwise we ignore it.
+ *
+ * @param params Request parameter object
+ */
+function resolvePermission(params) {
+  var dbPermissions = mBaaS.permission_map.db;
+  if(params.act && dbPermissions && dbPermissions[params.act]) {
+    params.requestedPermission = dbPermissions[params.act].requires;
+  }
+}
+
 function handleRequest(req, res) {
   var params = {},
       api = req.params.api,
@@ -53,6 +68,8 @@ function handleRequest(req, res) {
     },
     function (callback) {
       if ("db" === api) {
+        // Check the action and add the required permission to params
+        resolvePermission(params);
         authentication(req, res, params).authorise("AppCloudDB", callback);
       }
       /* will need to differentiate between CMS Administrator and CMS Editor
@@ -408,7 +425,8 @@ module.exports = function(fhMbaasApi) {
 
   mBaaS = {
     db: fh.db,
-    forms: fh.forms
+    forms: fh.forms,
+    permission_map: fh.permission_map
   };
 
   return app;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "FeedHenry MBAAS Express",
   "main": "lib/webapp.js",
   "dependencies": {
@@ -36,7 +36,7 @@
     "turbo-test-runner": "~0.3"
   },
   "scripts": {
-    "test": "grunt fh:coverage fh:analysis fh:dist"
+    "test": "grunt fh:coverage fh:dist"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-express
 sonar.projectName=fh-mbaas-express-nightly-master
-sonar.projectVersion=5.6.1
+sonar.projectVersion=5.6.2
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/accept/test_mbaas_db.js
+++ b/test/accept/test_mbaas_db.js
@@ -20,6 +20,9 @@ module.exports = {
         "x-fh-auth-app":"testkey"
       }
     }, function(err, response, data){
+        console.log("--------------------");
+        console.log(data);
+        console.log("--------------------");
       assert.ok(!err);
       assert.ok(data.list);
       assert.ok(typeof data.count === "number");

--- a/test/fixtures/authcall.js
+++ b/test/fixtures/authcall.js
@@ -1,7 +1,7 @@
 var nock = require('nock');
 
 module.exports = nock('https://testing.feedhenry.me')
- .get('/box/api/mbaas/admin/authenticateRequest?appApiKey=testkey&env=dev&requestedPerm=AppCloudDB')
+ .get('/box/api/mbaas/admin/authenticateRequest?appApiKey=testkey&env=dev&requestedPerm=AppCloudDB&requestedAct=read')
  .reply(200,{});
 
 

--- a/test/fixtures/mockAPI.js
+++ b/test/fixtures/mockAPI.js
@@ -65,6 +65,13 @@ var api = {
       //console.log("Called Mock Timing");
     }
   },
+  "permission_map": {
+    db: {
+      list: {
+        requires: "read"
+      }
+    }
+  },
   "db": function (params, callback) {
     console.log("Called db: ", params);
     var dbReplies = {


### PR DESCRIPTION
# Motivation

Append the `requestedAct` query parameter to the authorization request to millicore. This is used for a more fine grained (read/write level) control of authorization.

ping @ziccardi @wei-lee 