### PR TITLE
RHMAP-11705 - requested changes

### DIFF
--- a/test/unit/test_fhauth.js
+++ b/test/unit/test_fhauth.js
@@ -58,9 +58,9 @@ exports.it_shoudld_test_auth_failure = function (finish) {
     }
   };
 
-  var err = {
-    next: function () {
-      return err;
+  var error = {
+    body: {
+      "message": "error occured"
     }
   };
 
@@ -68,11 +68,11 @@ exports.it_shoudld_test_auth_failure = function (finish) {
   var performAuth = fhauth.__get__("performAuth");
   var authCall = performAuth(opts);
   mockAPI.auth.performAuth = function (req, localAuth, cb) {
-    return cb(null, err);
+    return cb(error);
   };
 
   authCall(req, res, function (err, resp) {
-    assert.ok(err);
+    assert.equal(err, error);
     return finish();
   });
 };


### PR DESCRIPTION
## Motivation

The studio preview for Web Apps (Embed Apps) incorrectly sends $fh.auth requests through the Web App and not through the domain.

## Solution
Once the new "auth" endpoint is added to fh-mbaas-api https://github.com/feedhenry/fh-mbaas-api/pull/28 expose both the url of the route, and the handler function in fh-mbaas-express.