### PR TITLE
Rhmap 11610 fix permission cache issue for data browser

### DIFF
--- a/lib/common/authenticate.js
+++ b/lib/common/authenticate.js
@@ -351,7 +351,7 @@ module.exports = function(req, res, params) {
       if (!env || !millicore) {
         return cb({
           code: 503,
-          "message": ""
+          "message": "missing environment variables"
         });
       }
       var now = new Date().getTime();
@@ -374,7 +374,7 @@ module.exports = function(req, res, params) {
           else {
             cb({
               code: 401,
-              "message": ""
+              "message": "unauthorised"
             });
           }
         }
@@ -409,7 +409,7 @@ module.exports = function(req, res, params) {
           };
           cb({
             code: 401,
-            "message": ""
+            "message": (data && data.message) || "unauthorised"
           });
         }
       });

--- a/lib/common/authenticate.js
+++ b/lib/common/authenticate.js
@@ -384,7 +384,6 @@ module.exports = function(req, res, params) {
 
       // Append `requestedAct` query parameter if possible
       authEndpoint = appendRequestedPermission(authEndpoint);
-      console.log("sending url" + authEndpoint);
 
       var headers = {};
       headers[USER_HEADER_KEY.toUpperCase()] = userApiKey;

--- a/lib/common/authenticate.js
+++ b/lib/common/authenticate.js
@@ -356,9 +356,18 @@ module.exports = function(req, res, params) {
       }
       var now = new Date().getTime();
 
+      var cacheKey = [userApiKey];
+      if (requestedPerm) {
+        cacheKey.push('-' + requestedPerm);
+      }
+      if (params.requestedPermission) {
+        cacheKey.push('-' + params.requestedPermission);
+      }
+      cacheKey = cacheKey.join('');
+
       //check cache
-      if (authorizationCache.hasOwnProperty(userApiKey)) {
-        var cache = authorizationCache[userApiKey];
+      if (authorizationCache.hasOwnProperty(cacheKey)) {
+        var cache = authorizationCache[cacheKey];
         //cache not timed out return cb else auth again
         if (cache.timeout > now) {
           if (cache.auth) return cb();
@@ -375,6 +384,7 @@ module.exports = function(req, res, params) {
 
       // Append `requestedAct` query parameter if possible
       authEndpoint = appendRequestedPermission(authEndpoint);
+      console.log("sending url" + authEndpoint);
 
       var headers = {};
       headers[USER_HEADER_KEY.toUpperCase()] = userApiKey;
@@ -388,13 +398,13 @@ module.exports = function(req, res, params) {
         }
 
         if (res.statusCode === 200) {
-          authorizationCache[userApiKey] = {
+          authorizationCache[cacheKey] = {
             "timeout": cacheLength,
             "auth": true
           };
           return cb();
         } else {
-          authorizationCache[userApiKey] = {
+          authorizationCache[cacheKey] = {
             "timeout": cacheLength,
             "auth": false
           };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.7",
+  "version": "5.6.8",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "plato": "^1.0.1",
     "proxyquire": "0.4.1",
     "rewire": "^2.5.2",
+    "sinon": "^1.17.7",
     "turbo-test-runner": "~0.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.7",
+  "version": "5.6.8",
   "description": "FeedHenry MBAAS Express",
   "main": "lib/webapp.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-express
 sonar.projectName=fh-mbaas-express-nightly-master
-sonar.projectVersion=5.6.7
+sonar.projectVersion=5.6.8
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/accept/test_mbaas_db.js
+++ b/test/accept/test_mbaas_db.js
@@ -2,13 +2,8 @@ var request = require('request');
 var nock = require('nock');
 var assert = require('assert');
 
-module.exports = {
-  "setUp" : function(finish){
-
-    finish();
-  },
-  "test DB call with correct api key and user key" : function(finish){
-    request.post(process.env.FH_TEST_HOSTNAME + '/mbaas/db/',
+function doDbList(cb) {
+  request.post(process.env.FH_TEST_HOSTNAME + '/mbaas/db/',
     {
       json:{
         "act": "list",
@@ -26,8 +21,17 @@ module.exports = {
       assert.ok(!err);
       assert.ok(data.list);
       assert.ok(typeof data.count === "number");
-      finish();
+      cb();
     });
+}
+
+module.exports = {
+  "setUp" : function(finish){
+
+    finish();
+  },
+  "test DB call with correct api key and user key" : function(finish){
+    doDbList(finish);
   },
   "test mbaas DB call with incorrect api key" : function(finish){
     request.post(process.env.FH_TEST_HOSTNAME + '/mbaas/db/',
@@ -62,6 +66,25 @@ module.exports = {
         assert.ok(response.statusCode === 401);
         finish();
       });
+  },
+  "test mbaas DB call with list and write" : function(finish) {
+    doDbList(function(err) {
+      assert.ok(!err, 'db list should work');
+      request.post(process.env.FH_TEST_HOSTNAME + '/mbaas/db/', {
+        json: {
+          "act": "create",
+          "type": "myFirstEntityy",
+          "__fh":{"appkey":"testkey","userkey":"akey"}
+        },
+        headers : {
+          'Content-Type' : 'application/json',
+          "x-fh-auth-app":"testkey"
+        }
+      }, function(err, response, data) {
+        assert.equal(response.statusCode, 401);
+        finish();
+      })
+    });
   },
   tearDown : function(finish){
     finish();

--- a/test/fixtures/authcall.js
+++ b/test/fixtures/authcall.js
@@ -2,7 +2,10 @@ var nock = require('nock');
 
 module.exports = nock('https://testing.feedhenry.me')
  .get('/box/api/mbaas/admin/authenticateRequest?appApiKey=testkey&env=dev&requestedPerm=AppCloudDB&requestedAct=read')
- .reply(200,{});
+ .times(2)
+ .reply(200,{})
+ .get('/box/api/mbaas/admin/authenticateRequest?appApiKey=testkey&env=dev&requestedPerm=AppCloudDB&requestedAct=write')
+ .reply(401,{});
 
 
 

--- a/test/fixtures/mockAPI.js
+++ b/test/fixtures/mockAPI.js
@@ -69,6 +69,9 @@ var api = {
     db: {
       list: {
         requires: "read"
+      },
+      create: {
+        requires: "write"
       }
     }
   },

--- a/test/unit/test-authorise.js
+++ b/test/unit/test-authorise.js
@@ -1,0 +1,38 @@
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+var assert = require('assert');
+
+var getFunc = sinon.stub();
+var authenticate = proxyquire('../../lib/common/authenticate', {
+  request: {
+    get: getFunc
+  }
+});
+
+module.exports = {
+  "test authorise caching": function(finish) {
+    process.env.FH_MILLICORE = 'testing.feedhenry.me';
+    process.env.FH_MILLICORE_PROTOCOL = 'https';
+    process.env.FH_ENV = "dev";
+
+    var req = {
+      headers: {
+        'x-fh-auth-app': "testkey",
+        'x-fh-auth-user': "fakeuserkey"
+      }
+    };
+    getFunc.yieldsAsync(null, {statusCode: 200}, {});
+    authenticate(req, {}, {requestedPermission: 'read'}).authorise('AppCloudDB', function(err) {
+      console.log(err);
+      assert.ok(!err, "authenticate.authorise read expects no error");
+
+      getFunc.yieldsAsync(null, {statusCode: 401}, {});
+      authenticate(req, {}, {requestedPermission: 'write'}).authorise('AppCloudDB', function(err) {
+        assert.ok(err, 'authenticate.authorise write expects error');
+
+        assert.equal(err.code, 401);
+        finish();
+      })
+    })
+  }
+}


### PR DESCRIPTION
## Motive

At the moment, a user without data browser write permission can still perform write operations. This is due to a cache issue in fh-mbaas-express. The "read" permission is being cached and used for "write" permission checks due to the same cache key is being used.

## Changes

Include the require permission as part of the cache key.

## JIRA

https://issues.jboss.org/browse/RHMAP-11610