### PR TITLE
Rhmap 12823

### DIFF
--- a/lib/fh-auth.js
+++ b/lib/fh-auth.js
@@ -5,6 +5,22 @@ var fhMbaasApi = require('./common/fhMbaasApi');
 var app = express.Router();
 var fh = fhMbaasApi.getFhApi();
 
+function sendResponse(status, body, res,  next) {
+  var response = body;
+
+  // The body is likely to be a string. We need to parse it in order
+  // to use it with the jQuery#json function
+  if (typeof body === 'string') {
+    try {
+      response = JSON.parse(body);
+    } catch(err) {
+      return next(err);
+    }
+  }
+
+  return res.status(status).json(response);
+}
+
 //performs authentication request ($fh.auth)
 function performAuth(opts) {
   var localAuth = opts.localAuth;
@@ -13,10 +29,11 @@ function performAuth(opts) {
       req.pause();
       fh.auth.performAuth(req, localAuth, function (err, fhres) {
         req.resume();
-        if (err) {
-          next(err);
+
+        if (err || !fhres) {
+          next(err || new Error("No response sent by authentication endpoint"));
         } else {
-          return res.status(fhres.status).json(fhres.body);
+          sendResponse(fhres.status, fhres.body, res, next);
         }
       });
     } else {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.8",
+  "version": "5.6.9",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.8",
+  "version": "5.6.9",
   "description": "FeedHenry MBAAS Express",
   "main": "lib/webapp.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-express
 sonar.projectName=fh-mbaas-express-nightly-master
-sonar.projectVersion=5.6.8
+sonar.projectVersion=5.6.9
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation

The millicore auth endpoint returns the `body` as string. We have to parse the (JSON) string because jQuery's `json` function expects an object. We are still doing a typecheck here because the implementatin of `performAuth` might change and auto-parse the body.