### PR TITLE
Fh 3140 add sync stats

### DIFF
--- a/lib/mbaas.js
+++ b/lib/mbaas.js
@@ -172,6 +172,16 @@ var app = express.Router();
 
     app.post('/:api', handleRequest);
 
+    app.get('/sync/stats', function(req, res){
+      if (fh.sync && fh.sync.getStats) {
+        fh.sync.getStats(function(err, results){
+          return endResponseCallback(req, res, err, results);
+        });
+      } else {
+        return endResponseCallback(req, res, new Error('sync stats is not supported'), null);
+      }
+    });
+
     app.post('/sync/:datasetId', function(req, res) {
       var params = {};
       var dataset_id = req.params.datasetId;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.10",
+  "version": "5.7.0",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "5.6.10",
+  "version": "5.7.0",
   "description": "FeedHenry MBAAS Express",
   "main": "lib/webapp.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-express
 sonar.projectName=fh-mbaas-express-nightly-master
-sonar.projectVersion=5.6.10
+sonar.projectVersion=5.7.0
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/accept/test_sync_stats.js
+++ b/test/accept/test_sync_stats.js
@@ -1,0 +1,15 @@
+var request = require('request');
+var assert = require('assert');
+
+module.exports = {
+  'test get sync stats ok' : function(finish) {
+    request.get(process.env.FH_TEST_HOSTNAME + '/mbaas/sync/stats', {
+      headers : {
+        'Content-Type' : 'application/json'
+      }
+    }, function(err, response, body){
+      assert.ok(response.statusCode === 200);
+      finish();
+    });
+  }
+};

--- a/test/fixtures/mockAPI.js
+++ b/test/fixtures/mockAPI.js
@@ -102,6 +102,11 @@ var api = {
     "performAuth": function(req, localAuth, cb) {
       return cb(null, localAuth);
     }
+  },
+  "sync": {
+    "getStats": function(cb) {
+      return cb(null, {});
+    }
   }
 };
 


### PR DESCRIPTION
This PR will add a new '/mbaas/sync/stats' endpoint to return the stats info about the sync framework.