### PR TITLE
RHMAP-21140: Update caching of requests to include unauthorised requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Jira link(s)
+
+
+
+# What
+
+
+
+# Why
+
+
+
+
+# How
+
+
+
+# Verification Steps
+
+
+
+## Checklist:
+
+- [ ] Code has been tested locally by PR requester
+- [ ] Changes have been successfully verified by another team member 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 lib-cov/
 .project
 .settings/
+.vscode/
 dist/
 output/
 man/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,11 +6,13 @@ module.exports = function(grunt) {
   grunt.initConfig({
     _test_runner: 'mocha',
     _unit_args: '-A -u exports --recursive -t 10000 ./test/unit',
+    _unit_single_args: '-A -u exports --recursive -t 10000',
     _accept_args: '-A -u exports --recursive -t 10000 ./test/setup.js ./test/accept',
 
     // These are the properties that grunt-fh-build will use
     unit: 'NO_FLUSH_TIMER=true <%= _test_runner %> <%= _unit_args %>',
     unit_cover: 'NO_FLUSH_TIMER=true istanbul cover --dir cov-unit <%= _test_runner %> -- <%= _unit_args %>',
+    unit_single: 'NO_FLUSH_TIMER=true <%= _test_runner %> <%= _unit_single_args %> ./test/unit/**/<%= unit_test_filename %> --grep=<%= unit_test_param1 %>',
 
     accept: 'NO_FLUSH_TIMER=true <%= _test_runner %> <%= _accept_args %>',
     accept_cover: 'NO_FLUSH_TIMER=true istanbul cover --dir cov-accept <%= _test_runner %> -- <%= _accept_args %>',

--- a/lib/common/authenticate.js
+++ b/lib/common/authenticate.js
@@ -115,7 +115,7 @@ module.exports = function(req, res, params) {
     });
   }
 
-   /**
+  /**
    * private
    */
   function authenticateAppApiKeyAgainstAuthorisedProjects(cb) {
@@ -143,7 +143,14 @@ module.exports = function(req, res, params) {
       //cache not timed out return cb else auth again
       if (cache.timeout > now) {
         // Cache hit
-        return cb();
+        if (cache.auth) {
+          return cb();
+        } else {
+          return cb({
+            code: UNAUTHORISED_HTTP_CODE,
+            message: cache.message
+          });
+        }
       } else {
         // Cache expired - remove and continue
         delete authenticateAppApiKeyAuthProjCache[sentApiKey];
@@ -165,7 +172,7 @@ module.exports = function(req, res, params) {
     }, function(err, res) {
       // Can set API_KEY_VALIDATION_TIMEOUT to expire more frequently than 5 minutes
       var expiration = parseInt(process.env.API_KEY_AUTH_PROJ_VALIDATION_TIMEOUT, 10) || 300000; // 5 minutes
-      var cacheLength = now + expiration; // 5 minutes
+      var cacheLength = new Date().getTime() + expiration; // 5 minutes
 
       // Explicitly handle 404s from Millicore here - the validate_key_against_authoried_projects endpoint may not exist in this cluster
       // If we get a 404, continue
@@ -186,12 +193,21 @@ module.exports = function(req, res, params) {
 
       if (res.statusCode === 200) {
         authenticateAppApiKeyAuthProjCache[sentApiKey] = {
-          "timeout": cacheLength
+          "timeout": cacheLength,
+          "auth": true,
+          "message": ""
         };
         return cb();
       } else {
         var errorMsg = (res.body && res.body.message) || "Invalid API Key";
         console.log("Issue validating app api key. Status Code: " + res.statusCode + ". Error Message: " + errorMsg);
+
+        authenticateAppApiKeyAuthProjCache[sentApiKey] = {
+          "timeout": cacheLength,
+          "auth": false,
+          "message": errorMsg
+        };
+
         return cb({
           code: UNAUTHORISED_HTTP_CODE,
           message: errorMsg

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "6.0.3",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "6.0.3",
+  "version": "6.1.0",
   "description": "FeedHenry MBAAS Express",
   "main": "lib/webapp.js",
   "dependencies": {

--- a/test/unit/test-authenticate.js
+++ b/test/unit/test-authenticate.js
@@ -1,6 +1,7 @@
 var authenticate = require('../../lib/common/authenticate');
 var assert = require('assert');
-var nockValidateKeyCall = require("../fixtures/validate_key_call");
+var nock = require('nock');
+require("../fixtures/validate_key_call");
 
 module.exports = {
   "test service access using allowed project id and correct api key": function(finish){
@@ -157,5 +158,177 @@ module.exports = {
       process.env.FH_SERVICE_ACCESS_KEY = "";
       finish();
     });
+  },
+  "test service access uses cached reponse for subsequent authorised requests": function(finish) {
+    process.env.FH_SERVICE_APP = 'true';
+    process.env.FH_SERVICE_AUTHORISED_PROJECTS = "projectguid1,projectguid2";
+    process.env.FH_MILLICORE = "testing.feedhenry.me";
+    process.env.FH_ENV = "dev";
+    
+    var req = {
+      headers: {
+        'x-request-with': "projectguid1",
+        'x-fh-auth-app': "rightkey"
+      }
+    };
+
+    // mock millicore call to return 200 for request with correct project and correct key
+    var authorisedInterceptor = nock('https://testing.feedhenry.me')
+      .persist()
+      .post('/box/api/projects/undefined/apps/undefined/validate_key_against_authorised_projects', {
+        "environment": "dev",
+        "clientApiKey": "rightkey"
+      })
+      .times(1)
+      .reply(200, {});
+
+    // Make service request with allowed & valid credentials project. Authorised response expected
+    authenticate(req, {}, {}).authenticate("some/path/to/something", function(err){
+      assert.ok(!err, "Expected valid call to be authorised " + err); //expect to be authorised
+
+      // mock millicore call to return unauthorised for request with correct project and correct key    
+      nock.removeInterceptor(authorisedInterceptor)
+      var unauthorisedInterceptor = nock('https://testing.feedhenry.me')
+        .persist()
+        .post('/box/api/projects/undefined/apps/undefined/validate_key_against_authorised_projects', {
+          "environment": "dev",
+          "clientApiKey": "rightkey"
+        })
+        .times(1)
+        .reply(401, {});
+
+      // Make same service call again - Authorised reponse expected due to caching
+      authenticate(req, {}, {}).authenticate("some/path/to/something", function(err){
+        //check that this call is served from the cache
+        assert.ok(!err, "Expected invalid call to still be authorised due to caching" + JSON.stringify(err, null, 2));
+
+        //Restore Env
+        nock.removeInterceptor(unauthorisedInterceptor);
+        process.env.FH_SERVICE_APP = '';
+        process.env.FH_SERVICE_AUTHORISED_PROJECTS = "";
+        finish();
+
+      });            
+    });    
+    
+  }, 
+  "test service access uses cached reponse for subsequent unauthorised requests": function(finish) {
+    process.env.FH_SERVICE_APP = 'true';
+    process.env.FH_SERVICE_AUTHORISED_PROJECTS = "projectguid1,projectguid2";
+    process.env.FH_MILLICORE = "testing.feedhenry.me";
+    process.env.FH_ENV = "dev";
+    
+    const req = {
+      headers: {
+        'x-request-with': "projectguid1",
+        'x-fh-auth-app': "otherkey"
+      }
+    };
+
+    // mock millicore call to return 401 for request
+    const unauthorisedInterceptor = nock('https://testing.feedhenry.me')
+      .persist()
+      .post('/box/api/projects/undefined/apps/undefined/validate_key_against_authorised_projects', {
+        "environment": "dev",
+        "clientApiKey": "otherkey"
+      })
+      .times(1)
+      .reply(401, {});
+
+    // Make service request. Expect 401 unauthorised response
+    authenticate(req, {}, {}).authenticate("some/path/to/something", function(err){
+      assert.ok(err, "Expected An Error ");
+      assert.equal(401, err.code);
+      assert.ok(err.message, "Invalid API Key");
+
+      // mock millicore call to return authorised for request with correct project and correct key    
+      nock.removeInterceptor(unauthorisedInterceptor)
+      const authorisedInterceptor = nock('https://testing.feedhenry.me')
+        .persist()
+        .post('/box/api/projects/undefined/apps/undefined/validate_key_against_authorised_projects', {
+          "environment": "dev",
+          "clientApiKey": "otherkey"
+        })
+        .times(1)
+        .reply(200, {});
+
+      // Make same service call again - Unauthorised reponse still expected due to caching
+      authenticate(req, {}, {}).authenticate("some/path/to/something", function(err){
+        //check that this call is served from the cache
+        assert.ok(err, "Expected An Error ");
+        assert.equal(401, err.code);
+        assert.ok(err.message, "Invalid API Key");
+
+        //Restore Env
+        nock.removeInterceptor(authorisedInterceptor);
+        process.env.FH_SERVICE_APP = '';
+        process.env.FH_SERVICE_AUTHORISED_PROJECTS = "";
+        finish();
+
+      });            
+    });        
+  }, 
+  "test stale service cache entries are not served": function(finish) {
+    //set env
+    process.env.FH_SERVICE_APP = 'true';
+    process.env.FH_SERVICE_AUTHORISED_PROJECTS = "projectguid1,projectguid2";
+    process.env.FH_MILLICORE = "testing.feedhenry.me";
+    process.env.FH_ENV = "dev";
+    process.env.API_KEY_AUTH_PROJ_VALIDATION_TIMEOUT = 1000; //reduce cache time
+    
+    const req = {
+      headers: {
+        'x-request-with': "projectguid1",
+        'x-fh-auth-app': "cacheTestKey"
+      }
+    };
+
+    // authorise service request
+    const authorisedInterceptor = nock('https://testing.feedhenry.me')
+      .persist()
+      .post('/box/api/projects/undefined/apps/undefined/validate_key_against_authorised_projects', {
+        "environment": "dev",
+        "clientApiKey": "cacheTestKey"
+      })
+      .times(1)
+      .reply(200, {});
+
+    authenticate(req, {}, {}).authenticate("some/path/to/something", function(err){
+      assert.ok(!err, "Expected valid call to be authorised " + err); //expect to be authorised  
+
+      // Make call again & expect unauthorised reponse as cache has expired
+      var expiration = parseInt(process.env.API_KEY_AUTH_PROJ_VALIDATION_TIMEOUT, 10) || 300000; // 5 minutes
+
+      setTimeout(function() {
+
+        // unauthorise request
+        nock.cleanAll(); 
+        const unauthorisedInterceptor = nock('https://testing.feedhenry.me')
+          .persist()
+          .post('/box/api/projects/undefined/apps/undefined/validate_key_against_authorised_projects', {
+            "environment": "dev",
+            "clientApiKey": "cacheTestKey"
+          })
+          .times(1)
+          .reply(401, {});
+         
+        // check request is now unauthorised & that expired authorised cache request is not returned  
+        authenticate(req, {}, {}).authenticate("some/path/to/something", function(err){
+
+          //check that this call is served from the cache
+          assert.ok(err, "Expected An Error ");
+          assert.equal(401, err.code);
+          assert.ok(err.message, "Invalid API Key");
+
+          //Restore Env
+          nock.cleanAll();      
+          process.env.FH_SERVICE_APP = '';
+          process.env.FH_SERVICE_AUTHORISED_PROJECTS = "";
+          finish();
+
+        })
+      }, (expiration + 1000));      
+      
+    })
   }
 };


### PR DESCRIPTION
# Jira link(s)

https://issues.jboss.org/browse/RHMAP-21140

# What

Update caching of requests to include unauthorised requests

# Why

Prevent unauthorised apps making large numbers of unauthorised requests from overloading the core


# How

Cache unauthorised requests

# Verification Steps
- verify unit tests pass by running `grunt fh:testfile:test-authenticate.js`

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 