### PR TITLE
 🐛 fix the error handler

### DIFF
--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -26,7 +26,9 @@ function handleUncaughtException(err) {
   });
 }
 
-function errHandler(err, req, res) {
+//NOTE: do not change the number of parameters here. Express app requires the error handlers to have EXACTLY 4 parameters.
+/* eslint-disable no-unused-vars */
+function errHandler(err, req, res, next) {
   console.log(addTimestamp("Internal error: " + util.inspect(err)));
   console.error(addTimestamp("Internal error: " + util.inspect(err)));
   if (err && err.stack) {
@@ -44,6 +46,7 @@ function errHandler(err, req, res) {
 
   return errorMessage;
 }
+/* eslint-enable */
 
 function errorHandler() {
   return errHandler;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1472,22 +1472,19 @@
           "integrity": "sha1-2X/uUUMCb6C0/WpdVkhfBEjrN8o=",
           "requires": {
             "lodash": "^4.0.0"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+              "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
+            }
           }
         },
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-        },
-        "ini": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "lodash": {
           "version": "4.17.10",
@@ -1513,6 +1510,33 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.2.11",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+              "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
+            },
+            "ini": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
+              "integrity": "sha1-ToCMLOFExsF4iRjgNNZ5e8bPYoE="
+            },
+            "optimist": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+              "requires": {
+                "wordwrap": "~0.0.2"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+                }
+              }
+            }
           }
         },
         "strip-json-comments": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
       }
     },
     "acorn": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
+      "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -485,9 +485,9 @@
       }
     },
     "commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
     "concat-map": {
@@ -1472,19 +1472,22 @@
           "integrity": "sha1-2X/uUUMCb6C0/WpdVkhfBEjrN8o=",
           "requires": {
             "lodash": "^4.0.0"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
-              "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
-            }
           }
         },
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "lodash": {
           "version": "4.17.10",
@@ -1510,33 +1513,6 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "deep-extend": {
-              "version": "0.2.11",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
-              "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
-            },
-            "ini": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
-              "integrity": "sha1-ToCMLOFExsF4iRjgNNZ5e8bPYoE="
-            },
-            "optimist": {
-              "version": "0.3.7",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-              "requires": {
-                "wordwrap": "~0.0.2"
-              },
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-                }
-              }
-            }
           }
         },
         "strip-json-comments": {
@@ -1893,7 +1869,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.5",
@@ -8481,12 +8456,6 @@
         "supports-color": "5.4.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "dev": true
-        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -9040,16 +9009,6 @@
         "uuid": "^3.0.0"
       },
       "dependencies": {
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
         "qs": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
@@ -9669,9 +9628,9 @@
       "optional": true
     },
     "winston": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
-      "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "FeedHenry MBAAS Express",
   "main": "lib/webapp.js",
   "dependencies": {


### PR DESCRIPTION
# Problem

In the latest version of the hello-world cloud app, if you try to send a request to an endpoint that doesn't exist, you will get a very long output in the logs and the following error:

```
TypeError: res.end is not a function
    at errHandler (/Users/weili/tmp/helloworld-cloud/node_modules/fh-mbaas-express/lib/errorHandler.js:42:9)
    at Layer.handle [as handle_request] (/Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/index.js:317:13)
    at /Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/index.js:335:12)
    at next (/Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/index.js:275:10)
    at /Users/weili/tmp/helloworld-cloud/node_modules/fh-mbaas-express/lib/fh-middleware.js:83:7
    at /Users/weili/tmp/helloworld-cloud/node_modules/fh-mbaas-express/lib/common/authenticate.js:392:18
    at verifyServiceAuthorisation (/Users/weili/tmp/helloworld-cloud/node_modules/fh-mbaas-express/lib/common/authenticate.js:257:14)
    at Object.authenticate (/Users/weili/tmp/helloworld-cloud/node_modules/fh-mbaas-express/lib/common/authenticate.js:381:7)
    at /Users/weili/tmp/helloworld-cloud/node_modules/fh-mbaas-express/lib/fh-middleware.js:45:38
    at Layer.handle [as handle_request] (/Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/index.js:317:13)
    at /Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/index.js:335:12)
    at next (/Users/weili/tmp/helloworld-cloud/node_modules/express/lib/router/index.js:275:10)
```

After investigation, the problem is that the `errorHandler` is missing a parameter, which makes it become a normal middleware rather than an error handler. 

# Verify:

The verify this change, the quickest way is to just run the hello-world cloud app, and send a http request to an endpoint that doesn't exist (e.g. favicon.ico) and see the output.

Then manually change the `errorHandler` file in the node_modules directory to add the missing parameter, run the app again and this time you will not see the error message.

@davidffrench @camilamacedo86 could you please verify this change? Thanks.