### PR TITLE
Removing console.debug statements, method does not exist in nodejs 6.x

### DIFF
--- a/lib/cloud/fh-reports.js
+++ b/lib/cloud/fh-reports.js
@@ -31,10 +31,8 @@ function sendReport(opts) {
     try {
       if (report) {
         var reporting = new FeedhenryReporting.Reporting(getMessagingConfig());
-        reporting.logMessage(topic, report, function(err, results) {
+        reporting.logMessage(topic, report, function() {
           /* ignoring callback */
-          console.debug(err);
-          console.debug(results);
         });
       }
     } catch (e) {

--- a/lib/common/message.js
+++ b/lib/common/message.js
@@ -66,9 +66,8 @@ module.exports = function() {
       retObj["sendErrorMessage"] = function(err , cb) {
         var message = retObj.createErrorMessage(err);
         amqpManager.publishTopic(messaging_exchange, "fh.events.nodeapp.app.crashed", message,
-          function(err) {
+          function() {
             //ignore errors
-            console.debug(err);
             cb();
           }
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-express",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "FeedHenry MBAAS Express",
   "main": "lib/webapp.js",
   "dependencies": {


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/FHOPS-4971


# What
Apps/Services crashing when making connections to RabbitMQ


# Why
console.debug method does not exist in NodeJS 6.x



# How
Remove console.debug statements


# Verification Steps



## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
